### PR TITLE
Allow overriding temporary directory with $TMPDIR env var

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -99,11 +99,11 @@ func indexAndPush(ctx context.Context, repo string, digest string, registryUrl s
 	return BuildAndPushSuccessMessage, nil
 }
 
-// Create a temp directory in /tmp
+// Create a temp directory in /tmp or $TMPDIR
 // The directory is prefixed by the Lambda's request id
 func createTempDir(ctx context.Context) (string, error) {
 	log.Info(ctx, "Creating a directory to store images and SOCI artifacts")
-	tempDir, err := os.MkdirTemp("/tmp", "soci") // The temp dir name is prefixed by the request id
+	tempDir, err := os.MkdirTemp("", "soci") // The temp dir name is prefixed by the request id
 	return tempDir, err
 }
 


### PR DESCRIPTION
Currently, the images and SOCI artifacts are stored in `/tmp` during processing, which is a very sensible default.

We run this in our CI environment where we have a 1GiB tmpfs volume at `/tmp`, so on some images we get this in our build logs.

```jsonc
{"level":"error","error":"errors encountered while building soci layers; write /tmp/tmp.3943925700: no space left on device; write /tmp/tmp.1788043098: no space left on device","RegistryURL":"<accountid>.dkr.ecr.<region>.amazonaws.com","ImageDigest":"<digest>","time":"2024-09-30T03:22:06Z","message":"SOCI index build error"}
```

I'd love to be able to override the temporary directory used by this program using the built-in `$TMPDIR` env var [recognised by the Go stdlib](https://pkg.go.dev/os#TempDir), for some specific builds.

### References

https://pkg.go.dev/os#MkdirTemp

> If dir is the empty string, MkdirTemp uses the default directory for temporary files, as returned by TempDir.

https://pkg.go.dev/os#TempDir

> On Unix systems, it returns $TMPDIR if non-empty, else /tmp.
