### PR TITLE
Add flag --allow-push-on-empty-index

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -30,7 +30,7 @@ var (
 const (
 	BuildFailedMessage         = "SOCI index build error"
 	PushFailedMessage          = "SOCI index push error"
-	PushOnEmptyIndexMessage    = "SOCI index does not contain any zTOCs. Re-tagging original image"
+	PushOnEmptyIndexMessage    = "SOCI index does not contain any zTOCs"
 	BuildAndPushSuccessMessage = "Successfully built and pushed SOCI index"
 
 	artifactsStoreName = "store"
@@ -81,10 +81,14 @@ func indexAndPush(ctx context.Context, repo string, tag string, newTags []string
 			if err.Error() == ErrEmptyIndex.Error() {
 				log.Warn(ctx, PushOnEmptyIndexMessage)
 
+				// tag when using --new-tag
+				// the user will be expecting those tags to exist whether or not we created an index
 				for _, newTag := range newTags {
-					err = registry.Tag(ctx, *desc, repo, newTag)
-					if err != nil {
-						return logAndReturnError(ctx, PushFailedMessage, err)
+					if newTag != tag {
+						err = registry.Tag(ctx, *desc, repo, newTag)
+						if err != nil {
+							return logAndReturnError(ctx, PushFailedMessage, err)
+						}
 					}
 				}
 				return PushOnEmptyIndexMessage, nil

--- a/handler.go
+++ b/handler.go
@@ -28,10 +28,10 @@ var (
 )
 
 const (
-	BuildFailedMessage          = "SOCI index build error"
-	PushFailedMessage           = "SOCI index push error"
-	SkipPushOnEmptyIndexMessage = "Skipping pushing SOCI index as it does not contain any zTOCs"
-	BuildAndPushSuccessMessage  = "Successfully built and pushed SOCI index"
+	BuildFailedMessage         = "SOCI index build error"
+	PushFailedMessage          = "SOCI index push error"
+	PushOnEmptyIndexMessage    = "SOCI index does not contain any zTOCs. Re-tagging original image"
+	BuildAndPushSuccessMessage = "Successfully built and pushed SOCI index"
 
 	artifactsStoreName = "store"
 	artifactsDbName    = "artifacts.db"
@@ -79,8 +79,15 @@ func indexAndPush(ctx context.Context, repo string, tag string, newTags []string
 		indexDescriptor, err := buildIndex(ctx, dataDir, sociStore, image)
 		if err != nil {
 			if err.Error() == ErrEmptyIndex.Error() {
-				log.Warn(ctx, SkipPushOnEmptyIndexMessage)
-				return SkipPushOnEmptyIndexMessage, nil
+				log.Warn(ctx, PushOnEmptyIndexMessage)
+
+				for _, newTag := range newTags {
+					err = registry.Tag(ctx, *desc, repo, newTag)
+					if err != nil {
+						return logAndReturnError(ctx, PushFailedMessage, err)
+					}
+				}
+				return PushOnEmptyIndexMessage, nil
 			}
 			return logAndReturnError(ctx, BuildFailedMessage, err)
 		}


### PR DESCRIPTION
Hey,

I ran into another issue with re-tagging images.

Images which are to small and therefore won't get an SOCI index are not pushed to the registry. This wasn't a problem when the index was pushed with the same tag as the source image, because the source image was already present in the registry. Now, with the option of specifying one or multiple new tags I cannot make any assumptions if these tags will be present after I ran the standalone-soci-indexer.

Solution: Add a new flag `--allow-push-on-empty-index` which re-tags the original image with the provided new-tags so it is guaranteed that these tags will be present.

Looking forward for your feedback!