### PR TITLE
Add proper multi arch support

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -38,10 +38,25 @@ const (
 	artifactsDbName    = "artifacts.db"
 )
 
+type registryClient interface {
+	Pull(ctx context.Context, repositoryName string, sociStore *store.SociStore, imageReference string) (*ocispec.Descriptor, error)
+	Push(ctx context.Context, sociStore *store.SociStore, indexDesc ocispec.Descriptor, repositoryName string) error
+	Tag(ctx context.Context, indexDesc ocispec.Descriptor, repositoryName, tag string) error
+	HeadManifest(ctx context.Context, repositoryName string, reference string) (ocispec.Descriptor, error)
+	ValidateImageManifest(ctx context.Context, repositoryName string, digest string) error
+}
+
+var (
+	initRegistry = func(ctx context.Context, registryUrl string, authToken string) (registryClient, error) {
+		return registryutils.Init(ctx, registryUrl, authToken)
+	}
+	buildIndexFn = buildIndex
+)
+
 func indexAndPush(ctx context.Context, repo string, tag string, newTags []string, registryUrl string, authToken string) (string, error) {
 	ctx = context.WithValue(ctx, "RegistryURL", registryUrl)
 
-	registry, err := registryutils.Init(ctx, registryUrl, authToken)
+	registry, err := initRegistry(ctx, registryUrl, authToken)
 	if err != nil {
 		return logAndReturnError(ctx, "Remote registry initialization error", err)
 	}
@@ -76,7 +91,7 @@ func indexAndPush(ctx context.Context, repo string, tag string, newTags []string
 		Target: *pulledDesc,
 	}
 
-	indexDescriptor, err := buildIndex(ctx, dataDir, sociStore, image)
+	indexDescriptor, err := buildIndexFn(ctx, dataDir, sociStore, image)
 	if err != nil {
 		if err.Error() == ErrEmptyIndex.Error() {
 			log.Warn(ctx, PushOnEmptyIndexMessage)
@@ -111,7 +126,7 @@ func indexAndPush(ctx context.Context, repo string, tag string, newTags []string
 	return BuildAndPushSuccessMessage, nil
 }
 
-func resolveSourceImageDescriptor(ctx context.Context, registry *registryutils.Registry, repo string, reference string) (ocispec.Descriptor, error) {
+func resolveSourceImageDescriptor(ctx context.Context, registry registryClient, repo string, reference string) (ocispec.Descriptor, error) {
 	desc, err := registry.HeadManifest(ctx, repo, reference)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -165,7 +180,7 @@ func initSociStore(ctx context.Context, dataDir string) (*store.SociStore, error
 	// expects a store.Store, an interface that extends the oci.Store to provide support
 	// for garbage collection.
 	ociStore, err := oci.NewWithContext(ctx, path.Join(dataDir, artifactsStoreName))
-	return &store.SociStore{ociStore}, err
+	return &store.SociStore{Store: ociStore}, err
 }
 
 // Init a new instance of SOCI artifacts DB

--- a/handler.go
+++ b/handler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/CloudSnorkel/standalone-soci-indexer/utils/log"
 	registryutils "github.com/CloudSnorkel/standalone-soci-indexer/utils/registry"
@@ -45,7 +46,7 @@ func indexAndPush(ctx context.Context, repo string, tag string, newTags []string
 		return logAndReturnError(ctx, "Remote registry initialization error", err)
 	}
 
-	digests, err := registry.GetImageDigests(ctx, repo, tag)
+	imageDesc, err := resolveSourceImageDescriptor(ctx, registry, repo, tag)
 	if err != nil {
 		log.Warn(ctx, fmt.Sprintf("Image manifest validation error: %v", err))
 		// Returning a non error to skip retries
@@ -63,55 +64,77 @@ func indexAndPush(ctx context.Context, repo string, tag string, newTags []string
 	if err != nil {
 		return logAndReturnError(ctx, "OCI storage initialization error", err)
 	}
+	ctx = context.WithValue(ctx, "ImageDigest", imageDesc.Digest.String())
 
-	for _, digest := range digests {
-		ctx := context.WithValue(ctx, "ImageDigest", digest)
-		desc, err := registry.Pull(ctx, repo, sociStore, digest)
-		if err != nil {
-			return logAndReturnError(ctx, "Image pull error", err)
-		}
+	pulledDesc, err := registry.Pull(ctx, repo, sociStore, tag)
+	if err != nil {
+		return logAndReturnError(ctx, "Image pull error", err)
+	}
 
-		image := images.Image{
-			Name:   repo + "@" + digest,
-			Target: *desc,
-		}
+	image := images.Image{
+		Name:   imageNameForReference(repo, tag),
+		Target: *pulledDesc,
+	}
 
-		indexDescriptor, err := buildIndex(ctx, dataDir, sociStore, image)
-		if err != nil {
-			if err.Error() == ErrEmptyIndex.Error() {
-				log.Warn(ctx, PushOnEmptyIndexMessage)
+	indexDescriptor, err := buildIndex(ctx, dataDir, sociStore, image)
+	if err != nil {
+		if err.Error() == ErrEmptyIndex.Error() {
+			log.Warn(ctx, PushOnEmptyIndexMessage)
 
-				// tag when using --new-tag
-				// the user will be expecting those tags to exist whether or not we created an index
-				for _, newTag := range newTags {
-					if newTag != tag {
-						err = registry.Tag(ctx, *desc, repo, newTag)
-						if err != nil {
-							return logAndReturnError(ctx, PushFailedMessage, err)
-						}
+			// tag when using --new-tag
+			// the user will be expecting those tags to exist whether or not we created an index
+			for _, newTag := range newTags {
+				if newTag != tag {
+					err = registry.Tag(ctx, *pulledDesc, repo, newTag)
+					if err != nil {
+						return logAndReturnError(ctx, PushFailedMessage, err)
 					}
 				}
-				return PushOnEmptyIndexMessage, nil
 			}
-			return logAndReturnError(ctx, BuildFailedMessage, err)
+			return PushOnEmptyIndexMessage, nil
 		}
-		ctx = context.WithValue(ctx, "SOCIIndexDigest", indexDescriptor.Digest.String())
+		return logAndReturnError(ctx, BuildFailedMessage, err)
+	}
+	ctx = context.WithValue(ctx, "SOCIIndexDigest", indexDescriptor.Digest.String())
 
-		err = registry.Push(ctx, sociStore, *indexDescriptor, repo)
+	err = registry.Push(ctx, sociStore, *indexDescriptor, repo)
+	if err != nil {
+		return logAndReturnError(ctx, PushFailedMessage, err)
+	}
+
+	for _, newTag := range newTags {
+		err = registry.Tag(ctx, *indexDescriptor, repo, newTag)
 		if err != nil {
 			return logAndReturnError(ctx, PushFailedMessage, err)
 		}
-
-		for _, newTag := range newTags {
-			err = registry.Tag(ctx, *indexDescriptor, repo, newTag)
-			if err != nil {
-				return logAndReturnError(ctx, PushFailedMessage, err)
-			}
-		}
-
-		log.Info(ctx, BuildAndPushSuccessMessage)
 	}
 	return BuildAndPushSuccessMessage, nil
+}
+
+func resolveSourceImageDescriptor(ctx context.Context, registry *registryutils.Registry, repo string, reference string) (ocispec.Descriptor, error) {
+	desc, err := registry.HeadManifest(ctx, repo, reference)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	switch desc.MediaType {
+	case registryutils.MediaTypeDockerManifest, registryutils.MediaTypeOCIManifest:
+		if err := registry.ValidateImageManifest(ctx, repo, desc.Digest.String()); err != nil {
+			return ocispec.Descriptor{}, err
+		}
+	case registryutils.MediaTypeDockerManifestList, registryutils.MediaTypeOCIIndexManifest:
+	default:
+		return ocispec.Descriptor{}, fmt.Errorf("unexpected manifest media type: %s", desc.MediaType)
+	}
+
+	return desc, nil
+}
+
+func imageNameForReference(repo string, reference string) string {
+	if strings.Contains(reference, ":") {
+		return repo + "@" + reference
+	}
+	return repo + ":" + reference
 }
 
 // Create a temp directory in /tmp or $TMPDIR
@@ -174,7 +197,12 @@ func buildIndex(ctx context.Context, dataDir string, sociStore *store.SociStore,
 		return nil, err
 	}
 
-	index, err := builder.Convert(ctx, image)
+	platforms, err := images.Platforms(ctx, containerdStore, image.Target)
+	if err != nil {
+		return nil, err
+	}
+
+	index, err := builder.Convert(ctx, image, soci.ConvertWithPlatforms(platforms...))
 	return index, err
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/soci/store"
+	"github.com/containerd/containerd/images"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	registryutils "github.com/CloudSnorkel/standalone-soci-indexer/utils/registry"
+)
+
+type fakeRegistry struct {
+	headDescriptor ocispec.Descriptor
+	headErr        error
+	pullDescriptor ocispec.Descriptor
+	validateErr    error
+	buildCalls     int
+
+	pullReferences []string
+	pushes         []ocispec.Descriptor
+	tags           []tagCall
+	validateCalls  []string
+}
+
+type tagCall struct {
+	desc ocispec.Descriptor
+	tag  string
+}
+
+func (f *fakeRegistry) Pull(_ context.Context, _ string, _ *store.SociStore, imageReference string) (*ocispec.Descriptor, error) {
+	f.pullReferences = append(f.pullReferences, imageReference)
+	desc := f.pullDescriptor
+	return &desc, nil
+}
+
+func (f *fakeRegistry) Push(_ context.Context, _ *store.SociStore, indexDesc ocispec.Descriptor, _ string) error {
+	f.pushes = append(f.pushes, indexDesc)
+	return nil
+}
+
+func (f *fakeRegistry) Tag(_ context.Context, indexDesc ocispec.Descriptor, _ string, tag string) error {
+	f.tags = append(f.tags, tagCall{desc: indexDesc, tag: tag})
+	return nil
+}
+
+func (f *fakeRegistry) HeadManifest(_ context.Context, _ string, _ string) (ocispec.Descriptor, error) {
+	return f.headDescriptor, f.headErr
+}
+
+func (f *fakeRegistry) ValidateImageManifest(_ context.Context, _ string, digest string) error {
+	f.validateCalls = append(f.validateCalls, digest)
+	return f.validateErr
+}
+
+func installTestHooks(t *testing.T, registry *fakeRegistry, build func(context.Context, string, *store.SociStore, images.Image) (*ocispec.Descriptor, error)) {
+	oldInitRegistry := initRegistry
+	oldBuildIndexFn := buildIndexFn
+	t.Cleanup(func() {
+		initRegistry = oldInitRegistry
+		buildIndexFn = oldBuildIndexFn
+	})
+
+	initRegistry = func(context.Context, string, string) (registryClient, error) {
+		return registry, nil
+	}
+	buildIndexFn = build
+}
+
+func runIndexAndPushTest(t *testing.T, registry *fakeRegistry, build func(context.Context, string, *store.SociStore, images.Image) (*ocispec.Descriptor, error)) (string, error) {
+	t.Helper()
+	installTestHooks(t, registry, build)
+	return indexAndPush(context.Background(), "example/repo", "latest", []string{"latest", "stable"}, "registry.example.com", "")
+}
+
+func TestIndexAndPush(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func(*testing.T) (*fakeRegistry, func(context.Context, string, *store.SociStore, images.Image) (*ocispec.Descriptor, error))
+		assert func(*testing.T, *fakeRegistry, string, error)
+	}{
+		{
+			name: "pushes aggregate index once for manifest list",
+			setup: func(t *testing.T) (*fakeRegistry, func(context.Context, string, *store.SociStore, images.Image) (*ocispec.Descriptor, error)) {
+				registry := &fakeRegistry{
+					headDescriptor: ocispec.Descriptor{
+						MediaType: registryutils.MediaTypeDockerManifestList,
+						Digest:    digest.Digest("sha256:1111111111111111111111111111111111111111111111111111111111111111"),
+					},
+					pullDescriptor: ocispec.Descriptor{
+						MediaType: registryutils.MediaTypeDockerManifestList,
+						Digest:    digest.Digest("sha256:1111111111111111111111111111111111111111111111111111111111111111"),
+					},
+				}
+
+				aggregateDesc := &ocispec.Descriptor{
+					MediaType: ocispec.MediaTypeImageIndex,
+					Digest:    digest.Digest("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+					Size:      123,
+				}
+
+				build := func(_ context.Context, _ string, _ *store.SociStore, image images.Image) (*ocispec.Descriptor, error) {
+					registry.buildCalls++
+					if image.Name != "example/repo:latest" {
+						t.Fatalf("unexpected image name: %s", image.Name)
+					}
+					if image.Target.Digest != registry.pullDescriptor.Digest {
+						t.Fatalf("unexpected image digest: %s", image.Target.Digest)
+					}
+					return aggregateDesc, nil
+				}
+
+				return registry, build
+			},
+			assert: func(t *testing.T, registry *fakeRegistry, message string, err error) {
+				if err != nil {
+					t.Fatalf("indexAndPush returned error: %v", err)
+				}
+				if message != BuildAndPushSuccessMessage {
+					t.Fatalf("unexpected message: %s", message)
+				}
+				if registry.buildCalls != 1 {
+					t.Fatalf("expected buildIndex to be called once, got %d", registry.buildCalls)
+				}
+				if len(registry.pullReferences) != 1 || registry.pullReferences[0] != "latest" {
+					t.Fatalf("unexpected pull references: %#v", registry.pullReferences)
+				}
+				if len(registry.pushes) != 1 || registry.pushes[0].Digest != digest.Digest("sha256:2222222222222222222222222222222222222222222222222222222222222222") {
+					t.Fatalf("unexpected pushes: %#v", registry.pushes)
+				}
+				if len(registry.tags) != 2 {
+					t.Fatalf("expected 2 tag calls, got %d", len(registry.tags))
+				}
+				if registry.tags[0].tag != "latest" || registry.tags[1].tag != "stable" {
+					t.Fatalf("unexpected tag sequence: %#v", registry.tags)
+				}
+				for _, tagCall := range registry.tags {
+					if tagCall.desc.Digest != digest.Digest("sha256:2222222222222222222222222222222222222222222222222222222222222222") {
+						t.Fatalf("tagged wrong descriptor: %s", tagCall.desc.Digest)
+					}
+				}
+				if len(registry.validateCalls) != 0 {
+					t.Fatalf("did not expect image manifest validation calls for manifest list, got %#v", registry.validateCalls)
+				}
+			},
+		},
+		{
+			name: "tags original image on empty index",
+			setup: func(t *testing.T) (*fakeRegistry, func(context.Context, string, *store.SociStore, images.Image) (*ocispec.Descriptor, error)) {
+				registry := &fakeRegistry{
+					headDescriptor: ocispec.Descriptor{
+						MediaType: registryutils.MediaTypeDockerManifest,
+						Digest:    digest.Digest("sha256:3333333333333333333333333333333333333333333333333333333333333333"),
+					},
+					pullDescriptor: ocispec.Descriptor{
+						MediaType: registryutils.MediaTypeDockerManifest,
+						Digest:    digest.Digest("sha256:3333333333333333333333333333333333333333333333333333333333333333"),
+					},
+				}
+
+				build := func(context.Context, string, *store.SociStore, images.Image) (*ocispec.Descriptor, error) {
+					return nil, ErrEmptyIndex
+				}
+
+				return registry, build
+			},
+			assert: func(t *testing.T, registry *fakeRegistry, message string, err error) {
+				if err != nil {
+					t.Fatalf("indexAndPush returned error: %v", err)
+				}
+				if message != PushOnEmptyIndexMessage {
+					t.Fatalf("unexpected message: %s", message)
+				}
+				if len(registry.pushes) != 0 {
+					t.Fatalf("expected no pushes, got %#v", registry.pushes)
+				}
+				if len(registry.tags) != 1 || registry.tags[0].tag != "stable" {
+					t.Fatalf("unexpected tag calls: %#v", registry.tags)
+				}
+				if registry.tags[0].desc.Digest != registry.pullDescriptor.Digest {
+					t.Fatalf("expected original image descriptor to be tagged, got %s", registry.tags[0].desc.Digest)
+				}
+				if len(registry.validateCalls) != 1 || registry.validateCalls[0] != "sha256:3333333333333333333333333333333333333333333333333333333333333333" {
+					t.Fatalf("unexpected validation calls: %#v", registry.validateCalls)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry, build := test.setup(t)
+			message, err := runIndexAndPushTest(t, registry, build)
+			test.assert(t, registry, message, err)
+		})
+	}
+}
+
+func TestResolveSourceImageDescriptor(t *testing.T) {
+	validationErr := errors.New("validation failed")
+	headErr := errors.New("head failed")
+
+	tests := []struct {
+		name                string
+		registry            *fakeRegistry
+		expectedDescriptor  ocispec.Descriptor
+		expectedErr         error
+		expectedErrMessage  string
+		expectedValidations []string
+	}{
+		{
+			name: "returns descriptor for manifest list without validation",
+			registry: &fakeRegistry{
+				headDescriptor: ocispec.Descriptor{
+					MediaType: registryutils.MediaTypeDockerManifestList,
+					Digest:    digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+				},
+			},
+			expectedDescriptor: ocispec.Descriptor{
+				MediaType: registryutils.MediaTypeDockerManifestList,
+				Digest:    digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			},
+		},
+		{
+			name: "validates docker manifest",
+			registry: &fakeRegistry{
+				headDescriptor: ocispec.Descriptor{
+					MediaType: registryutils.MediaTypeDockerManifest,
+					Digest:    digest.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+				},
+			},
+			expectedDescriptor: ocispec.Descriptor{
+				MediaType: registryutils.MediaTypeDockerManifest,
+				Digest:    digest.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+			},
+			expectedValidations: []string{"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+		},
+		{
+			name: "returns head manifest error",
+			registry: &fakeRegistry{
+				headErr: headErr,
+			},
+			expectedErr: headErr,
+		},
+		{
+			name: "returns validation error for image manifest",
+			registry: &fakeRegistry{
+				headDescriptor: ocispec.Descriptor{
+					MediaType: registryutils.MediaTypeOCIManifest,
+					Digest:    digest.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+				},
+				validateErr: validationErr,
+			},
+			expectedErr:         validationErr,
+			expectedValidations: []string{"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},
+		},
+		{
+			name: "rejects unexpected manifest type",
+			registry: &fakeRegistry{
+				headDescriptor: ocispec.Descriptor{
+					MediaType: "application/example",
+				},
+			},
+			expectedErrMessage:  "unexpected manifest media type: application/example",
+			expectedValidations: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			desc, err := resolveSourceImageDescriptor(context.Background(), test.registry, "example/repo", "latest")
+
+			if test.expectedErr != nil {
+				if !errors.Is(err, test.expectedErr) {
+					t.Fatalf("expected error %v, got %v", test.expectedErr, err)
+				}
+			} else if test.expectedErrMessage != "" {
+				if err == nil || err.Error() != test.expectedErrMessage {
+					t.Fatalf("expected error %q, got %v", test.expectedErrMessage, err)
+				}
+			} else if err != nil {
+				t.Fatalf("resolveSourceImageDescriptor returned error: %v", err)
+			}
+
+			if desc.MediaType != test.expectedDescriptor.MediaType || desc.Digest != test.expectedDescriptor.Digest {
+				t.Fatalf("unexpected descriptor: %#v", desc)
+			}
+
+			if len(test.registry.validateCalls) != len(test.expectedValidations) {
+				t.Fatalf("unexpected validation calls: %#v", test.registry.validateCalls)
+			}
+			for i, validation := range test.expectedValidations {
+				if test.registry.validateCalls[i] != validation {
+					t.Fatalf("unexpected validation calls: %#v", test.registry.validateCalls)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
In the old version multiple manifest-lists were created (see below). With this change, only one manifest-list with all available platforms is created and tagged. Fixes https://github.com/CloudSnorkel/standalone-soci-indexer/issues/22

Main changes:
- Remove loop over input digests
- Add platforms to ` builder.Convert`
- Add tests for handler.go

<details><summary>Input Manifest: amazon/aws-cli (Manifest-list with 2 manifests)</summary>
<p>

```
Name:        <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test@sha256:3a1e663f3429e4b677b7f4187e84ea833bad16e9d028360259baf2cf50e88e2a
MediaType:   application/vnd.docker.distribution.manifest.list.v2+json
Digest:      sha256:3a1e663f3429e4b677b7f4187e84ea833bad16e9d028360259baf2cf50e88e2a
             
Manifests:   
             
  Name:       <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test@sha256:74f1dfc1c5092b8d6e832eb8367ec6a52b013ea99ef91ea5b060962783d58c28
  Digest:    sha256:74f1dfc1c5092b8d6e832eb8367ec6a52b013ea99ef91ea5b060962783d58c28
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64
             
  Name:       <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test@sha256:4092982790a713adf8f43d3d4d155e041e7da1acabafec00fba4d58ef3082ce2
  Digest:    sha256:4092982790a713adf8f43d3d4d155e041e7da1acabafec00fba4d58ef3082ce2
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
``` 
</p>
</details> 

<details><summary>Old output: 2 Manifest-list; one for amd64 and one for arm64</summary>
<p>

```
Name:                                      <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test@sha256:4627a7f9a83095c4fbe34560b54df7bdadefb753ae9c5013ce6534561b838625
MediaType:                                 application/vnd.oci.image.index.v1+json
Digest:                                    sha256:4627a7f9a83095c4fbe34560b54df7bdadefb753ae9c5013ce6534561b838625
                                           
Manifests:                                 
                                           
  Name:                                    <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test@sha256:0a2c6b8cce9e583afbff1e3317152050b3b92d4402da4024b28ab9299447c002
  Digest:                                  sha256:0a2c6b8cce9e583afbff1e3317152050b3b92d4402da4024b28ab9299447c002
  MediaType:                               application/vnd.oci.image.manifest.v1+json
  Platform:                                linux/amd64
  Annotations:                             
    com.amazon.soci.index-digest:          sha256:3287fa8699d934c7991c94c264d7c7860b92744f232dfd57b98cd22a3da06336
                                           
  Name:                                    <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test@sha256:3287fa8699d934c7991c94c264d7c7860b92744f232dfd57b98cd22a3da06336
  Digest:                                  sha256:3287fa8699d934c7991c94c264d7c7860b92744f232dfd57b98cd22a3da06336
  MediaType:                               application/vnd.oci.image.manifest.v1+json
  ArtifactType:                            application/vnd.amazon.soci.index.v2+json
  Platform:                                linux/amd64
  Annotations:                             
    com.amazon.soci.image-manifest-digest: sha256:0a2c6b8cce9e583afbff1e3317152050b3b92d4402da4024b28ab9299447c002
``` 

```
Name:                                      <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test@sha256:d560a00d70f8b40dbcd4d6e99b179434a58520a92fb184664a2ecfc6c37d2810
MediaType:                                 application/vnd.oci.image.index.v1+json
Digest:                                    sha256:d560a00d70f8b40dbcd4d6e99b179434a58520a92fb184664a2ecfc6c37d2810
                                           
Manifests:                                 
                                           
  Name:                                    <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test@sha256:0b66976a0e99110ca572f1acb26987bd78905de7e1559e8227eaf3966f5507c6
  Digest:                                  sha256:0b66976a0e99110ca572f1acb26987bd78905de7e1559e8227eaf3966f5507c6
  MediaType:                               application/vnd.oci.image.manifest.v1+json
  Platform:                                linux/arm64
  Annotations:                             
    com.amazon.soci.index-digest:          sha256:75d83e52b90a9da7966873c135e86ed3c52708f303ca9356af0a9c727be7d4be
                                           
  Name:                                    <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test@sha256:75d83e52b90a9da7966873c135e86ed3c52708f303ca9356af0a9c727be7d4be
  Digest:                                  sha256:75d83e52b90a9da7966873c135e86ed3c52708f303ca9356af0a9c727be7d4be
  MediaType:                               application/vnd.oci.image.manifest.v1+json
  ArtifactType:                            application/vnd.amazon.soci.index.v2+json
  Platform:                                linux/arm64
  Annotations:                             
    com.amazon.soci.image-manifest-digest: sha256:0b66976a0e99110ca572f1acb26987bd78905de7e1559e8227eaf3966f5507c6

``` 

</p>
</details> 

<details><summary>New output: One Manifest-list</summary>
<p>

```
Name:                                      <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test:v1
MediaType:                                 application/vnd.oci.image.index.v1+json
Digest:                                    sha256:cf7d7ea308e424c740db70a48462a2093165a927bdd46ff1715570c8b8f4992d
                                           
Manifests:                                 
                                           
  Name:                                    <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test:v1@sha256:0a2c6b8cce9e583afbff1e3317152050b3b92d4402da4024b28ab9299447c002
  Digest:                                  sha256:0a2c6b8cce9e583afbff1e3317152050b3b92d4402da4024b28ab9299447c002
  MediaType:                               application/vnd.oci.image.manifest.v1+json
  Platform:                                linux/amd64
  Annotations:                             
    com.amazon.soci.index-digest:          sha256:3287fa8699d934c7991c94c264d7c7860b92744f232dfd57b98cd22a3da06336
                                           
  Name:                                    <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test:v1@sha256:0b66976a0e99110ca572f1acb26987bd78905de7e1559e8227eaf3966f5507c6
  Digest:                                  sha256:0b66976a0e99110ca572f1acb26987bd78905de7e1559e8227eaf3966f5507c6
  MediaType:                               application/vnd.oci.image.manifest.v1+json
  Platform:                                linux/arm64
  Annotations:                             
    com.amazon.soci.index-digest:          sha256:75d83e52b90a9da7966873c135e86ed3c52708f303ca9356af0a9c727be7d4be
                                           
  Name:                                    <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test:v1@sha256:3287fa8699d934c7991c94c264d7c7860b92744f232dfd57b98cd22a3da06336
  Digest:                                  sha256:3287fa8699d934c7991c94c264d7c7860b92744f232dfd57b98cd22a3da06336
  MediaType:                               application/vnd.oci.image.manifest.v1+json
  ArtifactType:                            application/vnd.amazon.soci.index.v2+json
  Platform:                                linux/amd64
  Annotations:                             
    com.amazon.soci.image-manifest-digest: sha256:0a2c6b8cce9e583afbff1e3317152050b3b92d4402da4024b28ab9299447c002
                                           
  Name:                                    <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test:v1@sha256:75d83e52b90a9da7966873c135e86ed3c52708f303ca9356af0a9c727be7d4be
  Digest:                                  sha256:75d83e52b90a9da7966873c135e86ed3c52708f303ca9356af0a9c727be7d4be
  MediaType:                               application/vnd.oci.image.manifest.v1+json
  ArtifactType:                            application/vnd.amazon.soci.index.v2+json
  Platform:                                linux/arm64
  Annotations:                             
    com.amazon.soci.image-manifest-digest: sha256:0b66976a0e99110ca572f1acb26987bd78905de7e1559e8227eaf3966f5507c6

``` 

</p>
</details> 

<details><summary>Test setup</summary>
<p>

Multi-arch test image:
```
regctl image copy docker.io/amazon/aws-cli:latest <account-id>.dkr.ecr.eu-central-1.amazonaws.com/stefan-soci-test:v1
``` 

</p>
</details> 
